### PR TITLE
docs: add bottom navigation to root

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -124,3 +124,5 @@ Email: [knowledge@itdo.jp](mailto:knowledge@itdo.jp)
 **著者:** ITDO Inc.  
 **バージョン:** 1.0.0  
 **最終更新:** 2025-07-19
+
+{% include page-navigation.html %}


### PR DESCRIPTION
Add bottom navigation include to docs/index.md so the root page shows prev/next/home controls.