### PR TITLE
CI: docs禁止物チェックを追加

### DIFF
--- a/.github/workflows/docs-forbidden-check.yml
+++ b/.github/workflows/docs-forbidden-check.yml
@@ -1,0 +1,30 @@
+name: Docs Forbidden Check
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  docs-forbidden:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check forbidden items in docs
+        shell: bash
+        run: |
+          set -euo pipefail
+          forbidden=(
+            "docs/project-management"
+            "docs/src"
+            "docs/package.json"
+            "docs/node_modules"
+          )
+          for path in "${forbidden[@]}"; do
+            if [ -e "$path" ]; then
+              echo "Forbidden path exists: $path"
+              exit 1
+            fi
+          done
+          echo "docs forbidden items: OK"


### PR DESCRIPTION
docs/ に生成物や管理用フォルダが混入しないよう、禁止物チェックをCIに追加します。