### PR TITLE
chore: add textlint to Book QA

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -1,4 +1,4 @@
-name: Book QA (Unicode + Links)
+name: Book QA (Unicode + Links + Textlint)
 
 on:
   pull_request:
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: itdojp/book-formatter
-          ref: e0fb33d224f368d7ce1830401e88e7e29053fb8e
+          ref: b4719a526043ee27554bc59ca18e4fec1d709812
           path: book-formatter
 
       - name: Setup Node.js
@@ -45,6 +45,9 @@ jobs:
 
       - name: Unicode check (fail on warnings)
         run: node book-formatter/scripts/check-unicode.js "${{ steps.scan.outputs.dir }}" --allowlist .book-formatter/unicode-allowlist.json --fail-on warn
+
+      - name: Textlint (PRH dictionary; non-blocking by default)
+        run: node book-formatter/scripts/check-textlint.js "${{ steps.scan.outputs.dir }}" --fail-on none
 
       - name: Link check (internal + anchors)
         run: node book-formatter/scripts/check-links.js "${{ steps.scan.outputs.dir }}"


### PR DESCRIPTION
book-formatter PR#66 で追加された textlint(PRH) チェックを各書籍の Book QA に横展開します。

- book-formatter ref を b4719a526043ee27554bc59ca18e4fec1d709812 に更新
- check-textlint.js を non-blocking（--fail-on none）で追加

関連: itdojp/it-engineer-knowledge-architecture#102
