### PR TITLE
chore: add PR template (QA/Pages checklist)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,17 +4,17 @@
 
 ## 影響範囲（必須）
 
-- 対象章/ページ（例: /chapters/chapter01/）:
+- 対象章/ページ（例: /path/to/page/）:
 - 影響（例: 追記 / 構成変更 / リンク修正 / 図表修正）:
 
 ## QA（必須）
 
 - [ ] Book QA（Unicode / textlint(PRH) / 内部リンク・アンカー / Jekyll build / built-site smoke）: PASS
-  - 実行URL:
+  - 実行URL: （GitHub Actions の workflow run URL）
 
 ## Pages確認（原則必須）
 
-- 確認URL: https://itdojp.github.io/ai-communication-book/
+- 確認URL: https://itdojp.github.io/ai-communication-book/ （fork/rename の場合は適宜読み替え）
 - [ ] トップページ HTTP 200
 - [ ] 主要導線（navigation.yml 相当）で 404 が無い
 - [ ] 表示崩れが無い（図表/表/コード中心）


### PR DESCRIPTION
https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102 Phase 3（PRテンプレ必須化）対応です。

- `.github/PULL_REQUEST_TEMPLATE.md` を追加/更新し、QA結果・Pages確認URL・影響範囲の記載を標準化

補足:
- 既存テンプレがあるリポジトリは、固有チェック項目を維持したまま必須項目（QA/Pages）を追記
