### PR TITLE
chore(ci): bump book-formatter pin

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: itdojp/book-formatter
-          ref: 0388ced8d757687c56697439e4bcf07062df5026
+          ref: 6b54a2abed0e2e8bbd8966bafddf0dd06131e114
           path: book-formatter
 
       - name: Setup Node.js


### PR DESCRIPTION
book-formatter の pin（Book QA で checkout する ref）を更新します。

- 変更: `0388ced` -> `6b54a2a`
- 目的: layout risk scan に「未クローズコードフェンス」検出を追加し、Markdown構造不整合による表示崩れをCIでブロック可能にする（book-formatter#73）

注: 参照先は commit SHA を pin し、チェックの再現性は維持します。