### PR TITLE
QA2: npm scripts を docs/ 構成に整合

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "AI時代のコミュニケーション技術 - 効果的なプロンプト設計とエージェント活用の実践的手法",
   "main": "index.md",
   "scripts": {
-    "start": "jekyll serve --livereload",
-    "build": "jekyll build",
+    "start": "cd docs && bundle exec jekyll serve --livereload",
+    "build": "cd docs && bundle exec jekyll build",
     "test": "npm run lint && npm run check-links",
-    "lint": "markdownlint src/**/*.md",
-    "check-links": "markdown-link-check src/**/*.md",
-    "deploy": "gh-pages -d _site"
+    "lint": "markdownlint docs/**/*.md",
+    "check-links": "markdown-link-check docs/**/*.md",
+    "deploy": "gh-pages -d docs/_site"
   },
   "keywords": [
     "book",


### PR DESCRIPTION
## 変更内容
- `package.json` の npm scripts を `docs/` 配下のJekyll構成に合わせて修正
  - `start`/`build`: `cd docs && bundle exec jekyll ...`
  - `lint`/`check-links`: `docs/**/*.md` を対象
  - `deploy`: `docs/_site` を対象

## 背景
- 現状は `src/**/*.md` を参照している一方、リポジトリに `src/` が存在しないため、`npm test` が意図どおり動作しません。
- `_config.yml` が `docs/` 配下にあるため、Jekyllは `docs/` を起点に実行する必要があります。

## 影響範囲
- ドキュメント本文は変更していません。
