### PR TITLE
docs: normalize license wording

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,15 +2,15 @@
 
 本書籍のライセンス条件は、株式会社アイティードゥの統一ライセンスに準拠します。
 
-📋 **詳細なライセンス条件：**  
+**詳細なライセンス条件：**  
 https://github.com/itdojp/it-engineer-knowledge-architecture/blob/main/LICENSE.md
 
 ## 簡易説明
 
-本作品は **Creative Commons BY-NC-SA 4.0** ライセンスで提供されています。
+本作品は **Creative Commons BY-NC-SA 4.0（CC BY-NC-SA 4.0）** ライセンスで提供されています。
 
-- **🔓 非営利利用：** 教育・研究・個人学習で自由に利用可能
-- **💼 商用利用：** 事前の商用ライセンス契約が必要
+- **非営利利用：** 教育・研究・個人学習で自由に利用可能
+- **商用利用：** 事前の商用ライセンス契約が必要
 
 **お問い合わせ：** knowledge@itdo.jp
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,15 +2,15 @@
 
 本書籍のライセンス条件は、株式会社アイティードゥの統一ライセンスに準拠します。
 
-📋 **詳細なライセンス条件：**  
+**詳細なライセンス条件：**  
 https://github.com/itdojp/it-engineer-knowledge-architecture/blob/main/LICENSE.md
 
 ## 簡易説明
 
-本作品は **Creative Commons BY-NC-SA 4.0** ライセンスで提供されています。
+本作品は **Creative Commons BY-NC-SA 4.0（CC BY-NC-SA 4.0）** ライセンスで提供されています。
 
-- **🔓 非営利利用：** 教育・研究・個人学習で自由に利用可能
-- **💼 商用利用：** 事前の商用ライセンス契約が必要
+- **非営利利用：** 教育・研究・個人学習で自由に利用可能
+- **商用利用：** 事前の商用ライセンス契約が必要
 
 **お問い合わせ：** knowledge@itdo.jp
 


### PR DESCRIPTION
## 変更内容
- `LICENSE` / `LICENSE.md`: ライセンス説明の装飾絵文字（📋/🔓/💼）を削除し、表記を統一
  - 「Creative Commons BY-NC-SA 4.0（CC BY-NC-SA 4.0）」に統一

## 意図
- 表記ゆれと装飾絵文字による可読性/体裁のブレを抑止するため。

## 確認
- `node ../book-formatter/scripts/check-unicode.js docs --allowlist .book-formatter/unicode-allowlist.json --fail-on warn`
  - errors: 0 / warnings: 0
