### PR TITLE
ci: update audited book-formatter pin

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: itdojp/book-formatter
-          ref: da2a49e7d2dcd9e1fa885e910c458130fe8d73a4
+          ref: 69eb5c12f5a750b65614bc9bbbc3d7abd5aa6f6c
           path: book-formatter
 
       - name: Setup Node.js


### PR DESCRIPTION
## Summary
- update only the active book-formatter pin to audited immutable 69eb5c12f5a750b65614bc9bbbc3d7abd5aa6f6c
- keep content, dependencies, QA, and build contract unchanged
## Verification
- actionlint
- git diff --check
- PR checks exercise QA and Pages
Closes #144
Parent: itdojp/it-engineer-knowledge-architecture#266
