### PR TITLE
chore: deprecated npm依存とhigh advisoryを解消

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -41,6 +41,11 @@ jobs:
       - name: Local npm security audit
         run: npm run check:security
 
+      - name: Audited dependency override contract
+        run: |
+          npm run check:dependencies
+          npm run check:dependencies-regression
+
       - name: Repository metadata consistency check
         run: node scripts/check-metadata.mjs
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "markdownlint-cli": "^0.49.1"
       },
       "engines": {
-        "node": ">=22.22.2"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       }
     },
     "node_modules/@exodus/bytes": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,28 @@
       "devDependencies": {
         "gh-pages": "^6.0.0",
         "markdown-link-check": "^3.11.2",
-        "markdownlint-cli": "^0.49.0"
+        "markdownlint-cli": "^0.49.1"
       },
       "engines": {
-        "node": ">=22.12.0"
+        "node": ">=22.22.2"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -233,9 +251,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -566,16 +584,19 @@
       "license": "MIT"
     },
     "node_modules/encoding-sniffer": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
-      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-1.0.2.tgz",
+      "integrity": "sha512-dlQ0jlnDJ2ElE1Ky4crYX0pPEPxQY9F2j+ZMIXlBedLJToEfDed9pvPqXg4fZnuu4qVBbcIrZVeg3S4aibTYGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "iconv-lite": "^0.6.3",
-        "whatwg-encoding": "^3.1.1"
+        "@exodus/bytes": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       },
       "funding": {
+        "type": "github",
         "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
       }
     },
@@ -960,13 +981,13 @@
       }
     },
     "node_modules/ini": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
-      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
+      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       }
     },
     "node_modules/ip-address": {
@@ -1090,9 +1111,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
       "dev": true,
       "funding": [
         {
@@ -1109,7 +1130,7 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/jsonc-parser": {
@@ -1184,9 +1205,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
       "funding": [
         {
@@ -1233,9 +1254,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
-      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
       "dev": true,
       "funding": [
         {
@@ -1250,8 +1271,8 @@
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -1303,9 +1324,9 @@
       }
     },
     "node_modules/markdownlint": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.41.0.tgz",
-      "integrity": "sha512-xMUI3ChBuRuxuLF4ENvCZyS8z/+Jly1coUcZwErKLIB3sDj7ojpaTBa1e9YVPhSN4jGEIjYGQCldbTJS/hqS+A==",
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.41.1.tgz",
+      "integrity": "sha512-qHKeU2E1bdyNAT077go2FVTNXvYcktN5IHtF6XyeD1l0PClxzSp2tUApAV14ORI8DGX4H9bNKZEzelZp4qn8IA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1327,23 +1348,23 @@
       }
     },
     "node_modules/markdownlint-cli": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.49.0.tgz",
-      "integrity": "sha512-vS5tWq5W91Gg33LD4pyAaXPclnz/sRvo6/RGOyDQjQ3eds2DkK6H4szUuE0M9TiRB/u/VBx1gtd9Ktrtx5WlSA==",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.49.1.tgz",
+      "integrity": "sha512-qpYqJbSYf3jv57bdnFmCaZ/Wlu6IYHp2b6SOKrKBJ7OnPrDHIKmx4NERWH49QH9viTI6yO6raVDDn5nrf60VQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "commander": "~15.0.0",
         "deep-extend": "~0.6.0",
-        "ignore": "~7.0.5",
-        "js-yaml": "~4.2.0",
+        "ignore": "~7.0.6",
+        "js-yaml": "~5.2.1",
         "jsonc-parser": "~3.3.1",
         "jsonpointer": "~5.0.1",
-        "markdown-it": "~14.2.0",
-        "markdownlint": "~0.41.0",
+        "markdown-it": "~14.3.0",
+        "markdownlint": "~0.41.1",
         "minimatch": "~10.2.5",
-        "run-con": "~1.3.2",
-        "smol-toml": "~1.6.1",
+        "run-con": "~1.3.3",
+        "smol-toml": "~1.7.0",
         "tinyglobby": "~0.2.17"
       },
       "bin": {
@@ -1364,9 +1385,9 @@
       }
     },
     "node_modules/markdownlint-cli/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2322,14 +2343,14 @@
       }
     },
     "node_modules/run-con": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/run-con/-/run-con-1.3.2.tgz",
-      "integrity": "sha512-CcfE+mYiTcKEzg0IqS08+efdnH0oJ3zV0wSUFBNrMHMuxCtXvBCLzCJHatwuXDcu/RlhjTziTo/a1ruQik6/Yg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/run-con/-/run-con-1.3.3.tgz",
+      "integrity": "sha512-Lb7OKM9aaykzyoNiHGhSVCjZsvbyy6qDMp2vDXL+MoCfz3GfNJtHYH7uYsU3QNMyInBk++xx+EZ8xZ8Sxs5fNQ==",
       "dev": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "dependencies": {
         "deep-extend": "^0.6.0",
-        "ini": "~4.1.0",
+        "ini": "~7.0.0",
         "minimist": "^1.2.8",
         "strip-json-comments": "~3.1.1"
       },
@@ -2410,9 +2431,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
-      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
+      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -2638,20 +2659,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/whatwg-encoding": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/whatwg-mimetype": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/itdojp/ai-communication-book.git"
   },
   "engines": {
-    "node": ">=22.22.2"
+    "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
   },
   "overrides": {
     "encoding-sniffer": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
   "scripts": {
     "start": "cd docs && bundle exec jekyll serve --livereload",
     "build": "cd docs && bundle exec jekyll build",
-    "test": "npm run check:metadata && npm run check:security && npm run lint && npm run check-links",
+    "test": "npm run check:metadata && npm run check:dependencies && npm run check:dependencies-regression && npm run check:security && npm run lint && npm run check-links",
     "lint": "markdownlint \"docs/**/*.md\"",
     "check-links": "find docs -name '*.md' -print0 | xargs -0 markdown-link-check --config .markdown-link-check.json",
     "deploy": "gh-pages -d docs/_site",
     "check:metadata": "node scripts/check-metadata.mjs",
+    "check:dependencies": "node scripts/check-dependency-contract.mjs",
+    "check:dependencies-regression": "node scripts/check-dependency-contract-regression.mjs",
     "check:security": "npm audit --audit-level=moderate"
   },
   "keywords": [
@@ -27,13 +29,18 @@
   "devDependencies": {
     "gh-pages": "^6.0.0",
     "markdown-link-check": "^3.11.2",
-    "markdownlint-cli": "^0.49.0"
+    "markdownlint-cli": "^0.49.1"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/itdojp/ai-communication-book.git"
   },
   "engines": {
-    "node": ">=22.12.0"
+    "node": ">=22.22.2"
+  },
+  "overrides": {
+    "encoding-sniffer": "1.0.2",
+    "brace-expansion": "5.0.7",
+    "js-yaml": "5.2.1"
   }
 }

--- a/scripts/check-dependency-contract-regression.mjs
+++ b/scripts/check-dependency-contract-regression.mjs
@@ -43,6 +43,15 @@ const cases = [
       pkg.engines.node = '>=22.12.0';
       lock.packages[''].engines.node = '>=22.12.0';
     }
+  },
+  {
+    name: 'a global override silently spreads to a new consumer',
+    mutate(_pkg, lock) {
+      lock.packages['node_modules/example-consumer'] = {
+        version: '1.0.0',
+        dependencies: { 'js-yaml': '^4.0.0' }
+      };
+    }
   }
 ];
 

--- a/scripts/check-dependency-contract-regression.mjs
+++ b/scripts/check-dependency-contract-regression.mjs
@@ -9,6 +9,19 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const TEMP_PARENT = path.join(ROOT, '.codex-local', 'tmp');
 fs.mkdirSync(TEMP_PARENT, { recursive: true });
 
+function removeDirectoryIfEmpty(directory) {
+  try {
+    fs.rmdirSync(directory);
+  } catch (error) {
+    if (!['ENOENT', 'ENOTEMPTY', 'EEXIST'].includes(error?.code)) throw error;
+  }
+}
+
+process.once('exit', () => {
+  removeDirectoryIfEmpty(TEMP_PARENT);
+  removeDirectoryIfEmpty(path.dirname(TEMP_PARENT));
+});
+
 const packageJson = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
 const packageLock = JSON.parse(fs.readFileSync(path.join(ROOT, 'package-lock.json'), 'utf8'));
 

--- a/scripts/check-dependency-contract-regression.mjs
+++ b/scripts/check-dependency-contract-regression.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { checkDependencyMetadata } from './check-dependency-contract.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const TEMP_PARENT = path.join(ROOT, '.codex-local', 'tmp');
+fs.mkdirSync(TEMP_PARENT, { recursive: true });
+
+const packageJson = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+const packageLock = JSON.parse(fs.readFileSync(path.join(ROOT, 'package-lock.json'), 'utf8'));
+
+const cases = [
+  {
+    name: 'deprecated dependency returns',
+    mutate(_pkg, lock) {
+      lock.packages['node_modules/whatwg-encoding'] = { version: '3.1.1' };
+    }
+  },
+  {
+    name: 'encoding override drifts',
+    mutate(pkg) {
+      pkg.overrides['encoding-sniffer'] = '0.2.1';
+    }
+  },
+  {
+    name: 'brace-expansion lock regresses',
+    mutate(_pkg, lock) {
+      lock.packages['node_modules/brace-expansion'].version = '5.0.6';
+    }
+  },
+  {
+    name: 'js-yaml lock regresses',
+    mutate(_pkg, lock) {
+      lock.packages['node_modules/js-yaml'].version = '4.2.0';
+    }
+  },
+  {
+    name: 'declared Node.js floor no longer covers installed dependencies',
+    mutate(pkg, lock) {
+      pkg.engines.node = '>=22.12.0';
+      lock.packages[''].engines.node = '>=22.12.0';
+    }
+  }
+];
+
+let passed = 0;
+for (const testCase of cases) {
+  const tempRoot = fs.mkdtempSync(path.join(TEMP_PARENT, 'dependency-contract-regression-'));
+  try {
+    const pkg = structuredClone(packageJson);
+    const lock = structuredClone(packageLock);
+    testCase.mutate(pkg, lock);
+    fs.writeFileSync(path.join(tempRoot, 'package.json'), `${JSON.stringify(pkg, null, 2)}\n`);
+    fs.writeFileSync(path.join(tempRoot, 'package-lock.json'), `${JSON.stringify(lock, null, 2)}\n`);
+    const failures = checkDependencyMetadata(tempRoot);
+    if (failures.length === 0) throw new Error(`${testCase.name}: checker accepted the invalid fixture`);
+    passed += 1;
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+const positive = checkDependencyMetadata(ROOT);
+if (positive.length > 0) {
+  console.error('positive fixture failed:');
+  for (const failure of positive) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(`Dependency contract regression passed: negative ${passed}/${cases.length}, positive 1/1`);

--- a/scripts/check-dependency-contract.mjs
+++ b/scripts/check-dependency-contract.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_ROOT = path.resolve(SCRIPT_DIR, '..');
+
+const EXPECTED_OVERRIDES = {
+  'encoding-sniffer': '1.0.2',
+  'brace-expansion': '5.0.7',
+  'js-yaml': '5.2.1'
+};
+
+const EXPECTED_LOCK_VERSIONS = {
+  'node_modules/markdown-link-check': '3.14.2',
+  'node_modules/cheerio': '1.2.0',
+  'node_modules/xmlbuilder2': '4.0.3',
+  'node_modules/encoding-sniffer': '1.0.2',
+  'node_modules/brace-expansion': '5.0.7',
+  'node_modules/js-yaml': '5.2.1',
+  'node_modules/markdownlint-cli': '0.49.1'
+};
+
+function readJson(root, relativePath, failures) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(root, relativePath), 'utf8'));
+  } catch (error) {
+    failures.push(`${relativePath}: ${error instanceof Error ? error.message : String(error)}`);
+    return {};
+  }
+}
+
+export function checkDependencyMetadata(root = DEFAULT_ROOT) {
+  const failures = [];
+  const pkg = readJson(root, 'package.json', failures);
+  const lock = readJson(root, 'package-lock.json', failures);
+  const packages = lock.packages ?? {};
+
+  if (pkg.devDependencies?.['markdownlint-cli'] !== '^0.49.1') {
+    failures.push('package.json: markdownlint-cli must be pinned to ^0.49.1');
+  }
+  if (pkg.engines?.node !== '>=22.22.2') {
+    failures.push('package.json: Node.js engine must cover the transitive ini@7 runtime requirement (>=22.22.2)');
+  }
+  if (packages['']?.engines?.node !== pkg.engines?.node) {
+    failures.push('package-lock.json: root Node.js engine must match package.json');
+  }
+
+  for (const [name, version] of Object.entries(EXPECTED_OVERRIDES)) {
+    if (pkg.overrides?.[name] !== version) {
+      failures.push(`package.json: override ${name} must be ${version}`);
+    }
+  }
+
+  for (const [packagePath, version] of Object.entries(EXPECTED_LOCK_VERSIONS)) {
+    if (packages[packagePath]?.version !== version) {
+      failures.push(`package-lock.json: ${packagePath} must resolve to ${version}`);
+    }
+  }
+
+  if (Object.hasOwn(packages, 'node_modules/whatwg-encoding')) {
+    failures.push('package-lock.json: deprecated whatwg-encoding must not be installed');
+  }
+
+  return failures;
+}
+
+async function checkRuntimeCompatibility(root, failures) {
+  try {
+    const { decodeBuffer, getEncoding } = await import('encoding-sniffer');
+    const cheerio = await import('cheerio');
+    const jsYaml = await import('js-yaml');
+    const { create } = await import('xmlbuilder2');
+
+    const html = Buffer.from('<meta charset="utf-8"><p>日本語</p>');
+    if (getEncoding(html) !== 'UTF-8' || !decodeBuffer(html).includes('日本語')) {
+      failures.push('encoding-sniffer: UTF-8 decoding compatibility smoke failed');
+    }
+
+    const $ = cheerio.loadBuffer(html);
+    if ($('p').text() !== '日本語') failures.push('cheerio: loadBuffer compatibility smoke failed');
+
+    const yaml = jsYaml.load('root:\n  item: ok\n');
+    if (yaml?.root?.item !== 'ok' || !jsYaml.dump(yaml).includes('item: ok')) {
+      failures.push('js-yaml: load/dump compatibility smoke failed');
+    }
+
+    const xml = create({ version: '1.0' }).ele('root').ele('item').txt('ok').end({ prettyPrint: false });
+    if (!xml.includes('<item>ok</item>')) failures.push('xmlbuilder2: XML writer compatibility smoke failed');
+  } catch (error) {
+    failures.push(`runtime dependency compatibility: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  const tempParent = path.join(root, '.codex-local', 'tmp');
+  fs.mkdirSync(tempParent, { recursive: true });
+  const tempDirectory = fs.mkdtempSync(path.join(tempParent, 'dependency-contract-'));
+  try {
+    const input = path.join(tempDirectory, 'input.md');
+    const report = path.join(tempDirectory, 'report.xml');
+    fs.writeFileSync(input, '# Dependency compatibility smoke\n');
+    execFileSync(
+      path.join(root, 'node_modules', '.bin', 'markdown-link-check'),
+      ['--reporters', 'junit', '--junit-output', report, input],
+      { cwd: root, stdio: 'pipe' }
+    );
+    const reportText = fs.readFileSync(report, 'utf8');
+    if (!reportText.includes('<testsuite')) failures.push('markdown-link-check: JUnit reporter smoke failed');
+  } catch (error) {
+    failures.push(`markdown-link-check compatibility: ${error instanceof Error ? error.message : String(error)}`);
+  } finally {
+    fs.rmSync(tempDirectory, { recursive: true, force: true });
+  }
+}
+
+export async function checkDependencyContract(root = DEFAULT_ROOT, options = {}) {
+  const failures = checkDependencyMetadata(root);
+  if (!options.staticOnly && failures.length === 0) await checkRuntimeCompatibility(root, failures);
+  return failures;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const failures = await checkDependencyContract(DEFAULT_ROOT);
+  if (failures.length > 0) {
+    console.error('Dependency contract check failed:');
+    for (const failure of failures) console.error(`- ${failure}`);
+    process.exit(1);
+  }
+  console.log('Dependency contract passed: audited overrides, lockfile, runtime APIs, and JUnit reporter');
+}

--- a/scripts/check-dependency-contract.mjs
+++ b/scripts/check-dependency-contract.mjs
@@ -57,8 +57,10 @@ export function checkDependencyMetadata(root = DEFAULT_ROOT) {
   if (pkg.devDependencies?.['markdownlint-cli'] !== '^0.49.1') {
     failures.push('package.json: markdownlint-cli must be pinned to ^0.49.1');
   }
-  if (pkg.engines?.node !== '>=22.22.2') {
-    failures.push('package.json: Node.js engine must cover the transitive ini@7 runtime requirement (>=22.22.2)');
+  if (pkg.engines?.node !== '^22.22.2 || ^24.15.0 || >=26.0.0') {
+    failures.push(
+      'package.json: Node.js engine must match the supported-major union required by transitive ini@7 (^22.22.2 || ^24.15.0 || >=26.0.0)'
+    );
   }
   if (packages['']?.engines?.node !== pkg.engines?.node) {
     failures.push('package-lock.json: root Node.js engine must match package.json');

--- a/scripts/check-dependency-contract.mjs
+++ b/scripts/check-dependency-contract.mjs
@@ -31,6 +31,14 @@ const EXPECTED_OVERRIDE_CONSUMERS = {
   'js-yaml': ['node_modules/markdownlint-cli', 'node_modules/xmlbuilder2']
 };
 
+function removeDirectoryIfEmpty(directory) {
+  try {
+    fs.rmdirSync(directory);
+  } catch (error) {
+    if (!['ENOENT', 'ENOTEMPTY', 'EEXIST'].includes(error?.code)) throw error;
+  }
+}
+
 function readJson(root, relativePath, failures) {
   try {
     return JSON.parse(fs.readFileSync(path.join(root, relativePath), 'utf8'));
@@ -131,6 +139,8 @@ async function checkRuntimeCompatibility(root, failures) {
     failures.push(`markdown-link-check compatibility: ${error instanceof Error ? error.message : String(error)}`);
   } finally {
     fs.rmSync(tempDirectory, { recursive: true, force: true });
+    removeDirectoryIfEmpty(tempParent);
+    removeDirectoryIfEmpty(path.dirname(tempParent));
   }
 }
 

--- a/scripts/check-dependency-contract.mjs
+++ b/scripts/check-dependency-contract.mjs
@@ -25,6 +25,12 @@ const EXPECTED_LOCK_VERSIONS = {
   'node_modules/markdownlint-cli': '0.49.1'
 };
 
+const EXPECTED_OVERRIDE_CONSUMERS = {
+  'encoding-sniffer': ['node_modules/cheerio'],
+  'brace-expansion': ['node_modules/minimatch'],
+  'js-yaml': ['node_modules/markdownlint-cli', 'node_modules/xmlbuilder2']
+};
+
 function readJson(root, relativePath, failures) {
   try {
     return JSON.parse(fs.readFileSync(path.join(root, relativePath), 'utf8'));
@@ -59,6 +65,18 @@ export function checkDependencyMetadata(root = DEFAULT_ROOT) {
   for (const [packagePath, version] of Object.entries(EXPECTED_LOCK_VERSIONS)) {
     if (packages[packagePath]?.version !== version) {
       failures.push(`package-lock.json: ${packagePath} must resolve to ${version}`);
+    }
+  }
+
+  for (const [dependency, expectedConsumers] of Object.entries(EXPECTED_OVERRIDE_CONSUMERS)) {
+    const actualConsumers = Object.entries(packages)
+      .filter(([, metadata]) => Object.hasOwn(metadata.dependencies ?? {}, dependency))
+      .map(([packagePath]) => packagePath)
+      .sort();
+    if (JSON.stringify(actualConsumers) !== JSON.stringify(expectedConsumers)) {
+      failures.push(
+        `package-lock.json: ${dependency} override consumers must remain ${expectedConsumers.join(', ')}; got ${actualConsumers.join(', ')}`
+      );
     }
   }
 


### PR DESCRIPTION
## 概要

Closes #143

`npm ci` の `whatwg-encoding@3.1.1` deprecation warningを解消し、同時に検出されたhigh severity advisory 3件を、本文変更と分離した依存専用変更として解消します。

## 変更内容

- `markdownlint-cli` を `0.49.0 -> 0.49.1` へ更新
- 監査済みtransitive overrideを固定
  - `encoding-sniffer@1.0.2`（`@exodus/bytes` 利用、`whatwg-encoding` 除去）
  - `brace-expansion@5.0.7`
  - `js-yaml@5.2.1`
- `ini@7` のruntime条件に合わせ、Node.js engineを `ini@7` と同じsupported-major union `^22.22.2 || ^24.15.0 || >=26.0.0` へ整合
- dependency contract checkerを追加
  - direct/override/lock version
  - override consumer集合の固定
  - deprecated `whatwg-encoding` 不在
  - `encoding-sniffer -> cheerio.loadBuffer`
  - `js-yaml` load/dump
  - `xmlbuilder2` XML writer
  - `markdown-link-check` JUnit reporter
- negative regression fixture 6件を追加し、`npm test` とBook QAに統合
- dependency check終了時にrepository-local scratch directoryを空の場合のみ削除

## Override判断

`markdown-link-check@3.14.2` と `cheerio@1.2.0` は現行最新版ですが、後者は `encoding-sniffer@^0.2.1` のままです。1.xは宣言範囲外のmajor更新であるため、lock対象のconsumer versions・consumer集合・実使用APIをcheckerで固定し、runtime smokeと既存全link checkで互換性を実証しています。upstreamが1.xを正式採用した時点でoverrideを再評価します。

`js-yaml@5` はmerge-keyの扱いを変更しますが、このrepositoryの利用経路はmarkdownlintとmarkdown-link-checkのXML/JUnit生成であり、YAML merge-keyに依存しません。実使用APIをcheckerで検証します。

## 検証

- clean `npm ci`: warning 0 / vulnerabilities 0
- `npm ci --engine-strict --ignore-scripts`: success
- `npm test`: success
  - dependency contract: success
  - regression: negative 6/6, positive 1/1
  - metadata / audit / markdownlint / external link check: success
  - 実行後のuntracked scratch artifact: 0
- `npm audit`: 0 vulnerabilities
- `npm run build`: success
- pinned `itdojp/book-formatter@69eb5c12f5a750b65614bc9bbbc3d7abd5aa6f6c`
  - Unicode / textlint / links / layout / structure: error 0
- `git diff --check`: success
- PR latest head `6d9802ca121bc1a27abe6eab2e13d4ed8bde904a`
  - Book QA: success
  - Docs Forbidden Check: success

## Review対応

- Codex P2 1件: dependency contract / regressionをBook QAへ明示統合して修正・返信・resolve
- Copilot 2件: scratch parent directoryの残存を空の場合のみ削除するよう修正・返信・resolve
- Codex P2 1件: Node engine rangeをtransitive `ini@7` のsupported-major unionへ整合して修正・返信・resolve
- 独立security review: blocking / high / medium / low 0

## 対象外

- #131 の本文全面改稿
- source URL / 書籍本文の変更
- 未監査のdependency major更新

